### PR TITLE
Material Subclasses

### DIFF
--- a/czml/czml.py
+++ b/czml/czml.py
@@ -1119,32 +1119,83 @@ class Path(_CZMLBaseObject):
                 raise ValueError('Key word %s not known' % k)
 
 
+class Grid(_CZMLBaseObject):
+    """Fills the surface with a grid."""
+    _color = None
+    _cellAlpha = None
+    _lineCount = None
+    _lineThickness = None
+    _lineOffset = None
+    _properties = ('color', 'cellAlpha', 'lineCount', 'lineThickness', 'lineOffset',)
+
+
+class Image(_CZMLBaseObject):
+    """Fills the surface with an image."""
+    _image = None
+    _repeat = None
+    _properties = ('image', 'repeat',)
+
+
+class Stripe(_CZMLBaseObject):
+    """Fills the surface with alternating colors."""
+    _orientation = None
+    _evenColor = None
+    _oddColor = None
+    _offset = None
+    _repeat = None
+    _properties = ('orientation', 'evenColor', 'oddColor', 'offset', 'repeat',)
+
+
 class SolidColor(_CZMLBaseObject):
     """Fills the surface with a solid color, which may be translucent."""
-    _properties = None
+    _color = None
     _properties = ('color',)
 
 
-class Image(_DateTimeAware):
-    """Fills the surface with an image."""
-    _image = None
-    _properties = ('image',)
+class PolylineGlow(_CZMLBaseObject):
+    """Colors the line with a glowing color."""
+    _color = None
+    _glowPower = None
+    _properties = ('color', 'glowPower',)
+
+
+class PolylineOutline(_CZMLBaseObject):
+    """Colors the line with a color and outline."""
+    _color = None
+    _outlineColor = None
+    _outlineWidth = None
+    _properties = ('color', 'outlineColor', 'outlineWidth',)
 
 
 class Material(_CZMLBaseObject):
     """The material to use to fill the polygon."""
+    _grid = None
     _image = None
+    _stripe = None
     _solidColor = None
+    _polylineGlow = None
+    _polylineOutline = None
 
-    _properties = ('image', 'solidColor')
+    _properties = ('grid', 'image', 'stripe', 'solidColor', 'polylineGlow', 'polylineOutline')
 
+    grid = class_property(Grid, 'grid',
+                          doc="""Fills the surface with a grid.
+                          """)
+    image = class_property(Image, 'image',
+                           doc="""The image to display on the surface.
+                           """)
+    stripe = class_property(Stripe, 'stripe',
+                            doc="""Fills the surface with alternating colors.
+                            """)
     solidColor = class_property(SolidColor, 'solidColor',
                                 doc="""Fills the surface with a solid color, which may be translucent.
                                 """)
-    image = class_property(Image, 'image',
-                           doc="""The image to display on the surface.
-
-    """)
+    polylineGlow = class_property(PolylineGlow, 'polylineGlow',
+                                  doc="""Colors the line with a glowing color.
+                                  """)
+    polylineOutline = class_property(PolylineOutline, 'polylineOutline',
+                                     doc="""Colors the line with a color and outline.
+                                     """)
 
 
 class Polygon(_CZMLBaseObject):

--- a/czml/test_main.py
+++ b/czml/test_main.py
@@ -312,13 +312,81 @@ class CzmlClassesTestCase(unittest.TestCase):
 
     def testMaterial(self):
         red = czml.Color(rgba=(255, 0, 0, 64))
-        mat = czml.Material(solidColor={'color': red})
+        mat = czml.Material()
         mat.solidColor = {'color': red}
         mat_dict = {'solidColor': {'color': {'rgba': [255, 0, 0, 64]}}}
         self.assertEqual(mat.data(), mat_dict)
-
         mat2 = czml.Material(**mat_dict)
         self.assertEqual(mat.data(), mat2.data())
+
+    def testGrid(self):
+        red = czml.Color(rgba=(255, 0, 0, 64))
+        g = czml.Grid()
+        g.color = red
+        g.cellAlpha = 0.5
+        g.lineCount = 4
+        g.lineThickness = 1.5
+        g.lineOffset = 0.75
+        g_dict = {'color': {'rgba': [255, 0, 0, 64]}, 'cellAlpha': 0.5, 'lineCount': 4,
+                  'lineThickness': 1.5, 'lineOffset': 0.75}
+        self.assertEqual(g.data(), g_dict)
+        g2 = czml.Grid(**g_dict)
+        self.assertEqual(g.data(), g2.data())
+
+    def testImage(self):
+        i = czml.Image()
+        i.image = 'http://localhost/img.png'
+        i.repeat = 3
+        i_dict = {'image': 'http://localhost/img.png', 'repeat': 3}
+        self.assertEqual(i.data(), i_dict)
+        i2 = czml.Image(**i_dict)
+        self.assertEqual(i.data(), i2.data())
+
+    def testStripe(self):
+        red = czml.Color(rgba=(255, 0, 0, 64))
+        grn = czml.Color(rgba=(0, 255, 0, 64))
+        s = czml.Stripe()
+        s.orientation = 'HORIZONTAL'
+        s.evenColor = red
+        s.oddColor = grn
+        s.offset = 1.5
+        s.repeat = 3.6
+        s_dict = {'orientation': 'HORIZONTAL', 'evenColor': {'rgba': [255, 0, 0, 64]},
+                  'oddColor': {'rgba': [0, 255, 0, 64]}, 'offset': 1.5, 'repeat': 3.6}
+        self.assertEqual(s.data(), s_dict)
+        s2 = czml.Stripe(**s_dict)
+        self.assertEqual(s.data(), s2.data())
+
+    def testSolidColor(self):
+        red = czml.Color(rgba=(255, 0, 0, 64))
+        sc = czml.SolidColor()
+        sc.color = red
+        sc_dict = {'color': {'rgba': [255, 0, 0, 64]}}
+        self.assertEqual(sc.data(), sc_dict)
+        sc2 = czml.SolidColor(**sc_dict)
+        self.assertEqual(sc.data(), sc2.data())
+
+    def testPolylineGlow(self):
+        red = czml.Color(rgba=(255, 0, 0, 64))
+        pg = czml.PolylineGlow()
+        pg.color = red
+        pg.glowPower = 0.25
+        pg_dict = {'color': {'rgba': [255, 0, 0, 64]}, 'glowPower': 0.25}
+        self.assertEqual(pg.data(), pg_dict)
+        pg2 = czml.PolylineGlow(**pg_dict)
+        self.assertEqual(pg.data(), pg2.data())
+
+    def testPolylineOutline(self):
+        red = czml.Color(rgba=(255, 0, 0, 64))
+        grn = czml.Color(rgba=(0, 255, 0, 64))
+        po = czml.PolylineOutline()
+        po.color = red
+        po.outlineColor = grn
+        po.outlineWidth = 4
+        po_dict = {'color': {'rgba': [255, 0, 0, 64]}, 'outlineColor': {'rgba': [0, 255, 0, 64]}, 'outlineWidth': 4}
+        self.assertEqual(po.data(), po_dict)
+        po2 = czml.PolylineOutline(**po_dict)
+        self.assertEqual(po.data(), po2.data())
 
     def testVertexPositions(self):
         v = czml.VertexPositions()


### PR DESCRIPTION
# Material Subclasses

This branch adds support for all six documented material subclasses:

* Grid
* Image
* Stripe
* SolidColor
* PolylineGlow
* PolylineOutline

As documented in [CZML Content](https://github.com/AnalyticalGraphicsInc/cesium/wiki/CZML-Content). Included are some minor fixes to existing subclasses and tests.

## Question: best approach for full test coverage

While I added test functions for each new class I did not add coverage of material subclasses in the (admittedly long) `testCZMLPacket` function. What is the intended long-term purpose of `testCZMLPacket`? Should it seek to implement every possible CZML element? If the test functions in this pull request are not sufficient on there own is there a better way to test their implementation without expanding `testCZMLPacket` into a thousand-line function over time?