### PR TITLE
Fix materials and positions, and 2d objects

### DIFF
--- a/czml/__init__.py
+++ b/czml/__init__.py
@@ -16,8 +16,9 @@
 #    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 from .czml import CZML, CZMLPacket
-from .czml import Position, Color, Billboard, Label, Point, SolidColor
-from .czml import VertexPositions, Polyline, Polygon, Material, Ellipse
+from .czml import Position, Color, Billboard, Label, Point
+from .czml import Grid, Image, Stripe, SolidColor, PolylineGlow, PolylineOutline
+from .czml import Positions, Polyline, Polygon, Material, Ellipse
 from .czml import Path, Ellipsoid, Number, Radii, Orientation
 from .utils import hexcolor_to_rgba
 

--- a/czml/czml.py
+++ b/czml/czml.py
@@ -146,7 +146,7 @@ class _CZMLBaseObject(object):
             if a is not None:
                 # These classes have a data method that should be called.
                 if isinstance(a, (_CZMLBaseObject, _Colors,
-                                  _Coordinates, _VPositions)):
+                                  _Coordinates, _Positions)):
                     d[attr] = a.data()
                 else:
                     d[attr] = a
@@ -753,7 +753,7 @@ class Clock(_CZMLBaseObject):
         self.step = data.get('step', None)
 
 
-class _VPositions(object):
+class _Positions(object):
     """ The list of positions [X, Y, Z, X, Y, Z, ...] """
 
     coords = None
@@ -786,7 +786,7 @@ class _VPositions(object):
         return self.coords
 
 
-class VertexPositions(_CZMLBaseObject):
+class Positions(_CZMLBaseObject):
     """The world-space positions of vertices.
     The vertex positions have no direct visual representation, but they
     are used to define polygons, polylines, and other objects attached
@@ -834,7 +834,7 @@ class VertexPositions(_CZMLBaseObject):
     @cartesian.setter
     def cartesian(self, geom):
         if geom is not None:
-            self._cartesian = _VPositions(geom)
+            self._cartesian = _Positions(geom)
         else:
             self._cartesian = None
 
@@ -849,7 +849,7 @@ class VertexPositions(_CZMLBaseObject):
     @cartographicDegrees.setter
     def cartographicDegrees(self, geom):
         if geom is not None:
-            self._cartographicDegrees = _VPositions(geom)
+            self._cartographicDegrees = _Positions(geom)
         else:
             self._cartographicDegrees = None
 
@@ -865,7 +865,7 @@ class VertexPositions(_CZMLBaseObject):
     @cartographicRadians.setter
     def cartographicRadians(self, geom):
         if geom is not None:
-            self._cartographicRadians = _VPositions(geom)
+            self._cartographicRadians = _Positions(geom)
         else:
             self._cartographicRadians = None
 
@@ -1171,12 +1171,12 @@ class Path(_CZMLBaseObject):
 
 class Polygon(_CZMLBaseObject):
     """A polygon, which is a closed figure on the surface of the Earth.
-    The vertices of the polygon are specified by the vertexPositions property.
+    The vertices of the polygon are specified by the positions property.
     """
     show = None
-    vertexPositions = None
+    positions = None
     _material = None
-    _properties = ('material', 'vertexPositions', 'show')
+    _properties = ('material', 'positions', 'show')
 
     def __init__(self, color=None, **kwargs):
         if color:
@@ -1344,7 +1344,7 @@ class CZMLPacket(_CZMLBaseObject):
     # The world-space positions of vertices. The vertex positions have no
     # direct visual representation, but they are used to define polygons,
     # polylines, and other objects attached to the object.
-    _vertexPositions = None
+    _positions = None
 
     # The orientation of the object in the world. The orientation has no
     # direct visual representation, but it is used to orient models,
@@ -1356,7 +1356,7 @@ class CZMLPacket(_CZMLBaseObject):
     _label = None
 
     # A polyline, which is a line in the scene composed of multiple segments.
-    # The vertices of the polyline are specified by the vertexPositions
+    # The vertices of the polyline are specified by the positions
     # property.
     _polyline = None
 
@@ -1367,7 +1367,7 @@ class CZMLPacket(_CZMLBaseObject):
     path = class_property(Path, 'path')
 
     # A polygon, which is a closed figure on the surface of the Earth.
-    # The vertices of the polygon are specified by the vertexPositions
+    # The vertices of the polygon are specified by the positions
     # property.
     _polygon = None
 
@@ -1530,24 +1530,24 @@ class CZMLPacket(_CZMLBaseObject):
             raise TypeError
 
     @property
-    def vertexPositions(self):
+    def positions(self):
         """The world-space positions of vertices.
         The vertex positions have no direct visual representation,
         but they are used to define polygons, polylines,
         and other objects attached to the object."""
-        if self._vertexPositions is not None:
-            return self._vertexPositions.data()
+        if self._positions is not None:
+            return self._positions.data()
 
-    @vertexPositions.setter
-    def vertexPositions(self, vpositions):
-        if isinstance(vpositions, VertexPositions):
-            self._vertexPositions = vpositions
+    @positions.setter
+    def positions(self, vpositions):
+        if isinstance(vpositions, Positions):
+            self._positions = vpositions
         elif isinstance(vpositions, dict):
-            p = VertexPositions()
+            p = Positions()
             p.load(vpositions)
-            self._vertexPositions = p
+            self._positions = p
         elif vpositions is None:
-            self._vertexPositions = None
+            self._positions = None
         else:
             raise TypeError
 
@@ -1555,7 +1555,7 @@ class CZMLPacket(_CZMLBaseObject):
     @property
     def polyline(self):
         """A polyline, which is a line in the scene composed of multiple segments.
-        The vertices of the polyline are specified by the vertexPositions
+        The vertices of the polyline are specified by the positions
         property."""
         if self._polyline is not None:
             return self._polyline.data()
@@ -1576,7 +1576,7 @@ class CZMLPacket(_CZMLBaseObject):
     @property
     def polygon(self):
         """A polygon, which is a closed figure on the surface of the Earth.
-        The vertices of the polygon are specified by the vertexPositions
+        The vertices of the polygon are specified by the positions
         property."""
 
         if self._polygon is not None:
@@ -1598,7 +1598,7 @@ class CZMLPacket(_CZMLBaseObject):
     @property
     def cone(self):
         """A polygon, which is a closed figure on the surface of the Earth.
-        The vertices of the polygon are specified by the vertexPositions
+        The vertices of the polygon are specified by the positions
         property."""
 
         if self._cone is not None:
@@ -1636,8 +1636,8 @@ class CZMLPacket(_CZMLBaseObject):
             d['label'] = self.label
         if self.point  is not None:
             d['point'] = self.point
-        if self.vertexPositions  is not None:
-            d['vertexPositions'] = self.vertexPositions
+        if self.positions  is not None:
+            d['positions'] = self.positions
         if self.polyline  is not None:
             d['polyline'] = self.polyline
         if self.polygon  is not None:
@@ -1661,7 +1661,7 @@ class CZMLPacket(_CZMLBaseObject):
         self.position = data.get('position', None)
         self.label = data.get('label', None)
         self.point = data.get('point', None)
-        self.vertexPositions = data.get('vertexPositions', None)
+        self.positions = data.get('positions', None)
         self.polyline = data.get('polyline', None)
         self.polygon = data.get('polygon', None)
 

--- a/czml/czml.py
+++ b/czml/czml.py
@@ -1113,102 +1113,130 @@ class Material(_CZMLBaseObject):
                                      """)
 
 
-class Polyline(_DateTimeAware, _CZMLBaseObject):
-    """ A polyline, which is a line in the scene composed of multiple segments.
-    """
-
-    show = None
-    width = None
-    followSurface = None
-
-    _material = None
-    material = class_property(Material, 'material',
-                              doc="""The material to use to draw the polyline.""")
-
-    _positions = None
-    positions = class_property(Positions, 'positions',
-                               doc="""The array of positions defining the polyline as a line strip.""");
-
-    _properties = ('show', 'width', 'followSurface', 'material', 'positions')
-
-
-class Path(_CZMLBaseObject):
+class Path(_DateTimeAware, _CZMLBaseObject):
     """A path, which is a polyline defined by the motion of an object over
     time. The possible vertices of the path are specified by the position
     property."""
-
     show = None
 
-    _color = None
-    color = class_property(Color, 'color')
+    _width = None
+    width = class_property(Number, 'width');
+    
+    _leadTime = None
+    leadTime = class_property(Number, 'leadTime');
 
-    resolution = None
-    outlineWidth = None
-    leadTime = None
-    trailTime = None
-    width = None
+    _trailTime = None
+    trailTime = class_property(Number, 'trailTime');
 
-    _position = None
-    position = class_property(Position, 'position')
+    _resolution = None
+    resolution = class_property(Number, 'resolution');
 
-    @property
-    def properties(self):
-        return super(Path, self).properties + ('show', 'color', 'resolution',
-                                               'outlineWidth', 'leadTime',
-                                               'trailTime', 'position', 'width')
-
-    def __init__(self, **kwargs):
-        if hasattr(kwargs, 'iteritems'):
-            iterator = kwargs.iteritems
-        elif hasattr(kwargs, 'items'):
-            iterator = kwargs.items
-        for k, v in iterator():
-            if k in self._properties:
-                setattr(self, k, v)
-            else:
-                raise ValueError('Key word %s not known' % k)
-
-
-class Polygon(_CZMLBaseObject):
-    """A polygon, which is a closed figure on the surface of the Earth.
-    The vertices of the polygon are specified by the positions property.
-    """
-    show = None
-    positions = None
     _material = None
-    _properties = ('material', 'positions', 'show')
-
-    def __init__(self, color=None, **kwargs):
-        if color:
-            self.material = {"solidColor":{"color": color}}
-        super(Polygon, self).__init__(**kwargs)
-
     material = class_property(Material, 'material')
 
+    _position = None
+    position = class_property(Position, 'position');
 
-class Ellipse(_CZMLBaseObject):
-    """
-    An ellipse, which is a closed curve on the surface of the Earth. The
-    ellipse is positioned using the position property.
+    _properties = ('show', 'width', 'leadTime', 'trailTime',
+                   'resolution', 'material', 'position')
 
-    Note that this requires a polygon or polyline to actually get drawn!
+
+class Polyline(_DateTimeAware, _CZMLBaseObject):
+    """ A polyline, which is a line in the scene composed of multiple segments.
     """
-    _properties = ('semiMajorAxis', 'semiMinorAxis', 'bearing')
-    _bearing = None
+    show = None
+    followSurface = None
+
+    _width = None
+    width = class_property(Number, 'width');
+
+    _material = None
+    material = class_property(Material, 'material')
+
+    _positions = None
+    positions = class_property(Positions, 'positions');
+
+    _properties = ('show', 'followSurface', 'width', 'material', 'positions')
+
+
+class Polygon(_DateTimeAware, _CZMLBaseObject):
+    """A polygon, which is a closed figure on the surface of the Earth.
+    """
+    show = None
+    fill = None
+    outline = None
+    perPositionHeight = None
+
+    _height = None
+    height = class_property(Number, 'height')
+
+    _stRotation = None
+    stRotation = class_property(Number, 'stRotation')
+
+    _granularity = None
+    granularity = class_property(Number, 'granularity')
+
+    _extrudedHeight = None
+    extrudedHeight = class_property(Number, 'extrudedHeight')
+    
+    _outlineColor = None
+    outlineColor = class_property(Color, 'outlineColor')
+
+    _material = None
+    material = class_property(Material, 'material')
+
+    _positions = None
+    positions = class_property(Positions, 'positions');
+
+    _properties = ('show', 'fill', 'height', 'outline', 'stRotation',
+                   'granularity', 'extrudedHeight', 'perPositionHeight',
+                   'outlineColor', 'material', 'positions')
+
+
+class Ellipse(_DateTimeAware, _CZMLBaseObject):
+    """An ellipse, which is a closed curve on the surface of the Earth.
+       The ellipse is positioned using the position property.
+    """
+    show = None
+    fill = None
+    outline = None
+
+    _height = None
+    height = class_property(Number, 'height')
+
+    _rotation = None
+    rotation = class_property(Number, 'rotation')
+
+    _stRotation = None
+    stRotation = class_property(Number, 'stRotation')
+
+    _granularity = None
+    granularity = class_property(Number, 'granularity')
+
     _semiMajorAxis = None
+    semiMajorAxis = class_property(Number, 'semiMajorAxis')
+
     _semiMinorAxis = None
+    semiMinorAxis = class_property(Number, 'semiMinorAxis')
 
-    bearing = class_property(Number, 'bearing', doc="""
-    The angle from north (clockwise) in radians.
-    """)
+    _extrudedHeight = None
+    extrudedHeight = class_property(Number, 'extrudedHeight')
 
-    semiMajorAxis = class_property(Number, 'semiMajorAxis', doc="""
-    The length of the ellipse's semi-major axis in meters.
-    """)
+    _numberOfVerticalLines = None
+    numberOfVerticalLines = class_property(Number, 'numberOfVerticalLines')
+    
+    _outlineColor = None
+    outlineColor = class_property(Color, 'outlineColor')
 
-    semiMinorAxis = class_property(Number, 'semiMinorAxis', doc="""
-    The length of the ellipse's semi-minor axis in meters.
-    """)
+    _material = None
+    material = class_property(Material, 'material')
+
+    _position = None
+    position = class_property(Position, 'position');
+
+    _properties = ('show', 'fill', 'outline', 'height', 'rotation', 'stRotation',
+                   'granularity', 'extrudedHeight', 'semiMajorAxis', 'semiMinorAxis',
+                   'numberOfVerticalLines', 'outlineColor', 'material', 'position')
 
 
 class Ellipsoid(_DateTimeAware):

--- a/czml/czml.py
+++ b/czml/czml.py
@@ -118,10 +118,9 @@ def datetime_property(name, allow_offset=False, doc=None):
 
     return property(getter, setter, doc=doc)
 
-# We make lots of material properties.
-material_property = lambda x: class_property(Material, x, doc=
-    """The material to use to fill in the object you are creating.
-    """)
+# Many classes will have material and position properties.
+material_property = lambda x: class_property(Material, x)
+position_property = lambda x: class_property(Position, x)
 
 
 class _CZMLBaseObject(object):
@@ -1035,136 +1034,6 @@ class Label(_CZMLBaseObject):
         self.text = data.get('text', None)
 
 
-class Polyline(_CZMLBaseObject):
-    """ A polyline, which is a line in the scene composed of multiple segments.
-    The vertices of the polyline are specified by the vertexPositions property.
-    """
-
-    # Whether or not the polyline is shown.
-    show = False
-
-    _color = None
-    _outlineColor = None
-
-    # The width of the outline of the polyline.
-    outlineWidth = None
-
-    # The width of the polyline.
-    width = None
-
-    def __init__(self, show=False, color=None, width=None,
-                outlineColor=None, outlineWidth=None):
-        self.show = show
-        self.color = color
-        self.width = width
-        self.outlineColor = outlineColor
-        self.outlineWidth = outlineWidth
-
-
-
-    @property
-    def color(self):
-        """The color of the polyline."""
-        if self._color is not None:
-            return self._color.data()
-
-    @color.setter
-    def color(self, color):
-        if isinstance(color, Color):
-            self._color = color
-        elif isinstance(color, dict):
-            col = Color()
-            col.load(color)
-            self._color = col
-        elif color is None:
-            self._color = None
-        else:
-            raise TypeError
-
-    @property
-    def outlineColor(self):
-        """The color of the outline of the polyline."""
-        if self._outlineColor is not None:
-            return self._outlineColor.data()
-
-    @outlineColor.setter
-    def outlineColor(self, color):
-        if isinstance(color, Color):
-            self._outlineColor = color
-        elif isinstance(color, dict):
-            col = Color()
-            col.load(color)
-            self._outlineColor = col
-        elif color is None:
-            self._outlineColor = None
-        else:
-            raise TypeError
-
-
-
-
-    def data(self):
-        d = {}
-        if self.show:
-            d['show'] = True
-        if self.show == False:
-            d['show'] = False
-        if self.color:
-            d['color'] = self.color
-        if self.width:
-            d['width'] = self.width
-        if self.outlineColor:
-            d['outlineColor'] = self.outlineColor
-        if self.outlineWidth:
-            d['outlineWidth'] = self.outlineWidth
-
-        return d
-
-    def load(self, data):
-        self.show = data.get('show', None)
-        self.color = data.get('color', None)
-        self.outlineColor = data.get('outlineColor', None)
-        self.width = data.get('width', None)
-        self.outlineWidth = data.get('outlineWidth', None)
-
-
-class Path(_CZMLBaseObject):
-    """A path, which is a polyline defined by the motion of an object over
-    time. The possible vertices of the path are specified by the position
-    property."""
-
-    show = None
-
-    _color = None
-    color = class_property(Color, 'color')
-
-    resolution = None
-    outlineWidth = None
-    leadTime = None
-    trailTime = None
-    width = None
-
-    _position = None
-    position = class_property(Position, 'position')
-
-    @property
-    def properties(self):
-        return super(Path, self).properties + ('show', 'color', 'resolution',
-                                               'outlineWidth', 'leadTime',
-                                               'trailTime', 'position', 'width')
-
-    def __init__(self, **kwargs):
-        if hasattr(kwargs, 'iteritems'):
-            iterator = kwargs.iteritems
-        elif hasattr(kwargs, 'items'):
-            iterator = kwargs.items
-        for k, v in iterator():
-            if k in self._properties:
-                setattr(self, k, v)
-            else:
-                raise ValueError('Key word %s not known' % k)
-
-
 class Grid(_CZMLBaseObject):
     """Fills the surface with a grid."""
     _color = None
@@ -1242,6 +1111,62 @@ class Material(_CZMLBaseObject):
     polylineOutline = class_property(PolylineOutline, 'polylineOutline',
                                      doc="""Colors the line with a color and outline.
                                      """)
+
+
+class Polyline(_DateTimeAware, _CZMLBaseObject):
+    """ A polyline, which is a line in the scene composed of multiple segments.
+    """
+
+    show = None
+    width = None
+    followSurface = None
+
+    _material = None
+    material = class_property(Material, 'material',
+                              doc="""The material to use to draw the polyline.""")
+
+    _positions = None
+    positions = class_property(Positions, 'positions',
+                               doc="""The array of positions defining the polyline as a line strip.""");
+
+    _properties = ('show', 'width', 'followSurface', 'material', 'positions')
+
+
+class Path(_CZMLBaseObject):
+    """A path, which is a polyline defined by the motion of an object over
+    time. The possible vertices of the path are specified by the position
+    property."""
+
+    show = None
+
+    _color = None
+    color = class_property(Color, 'color')
+
+    resolution = None
+    outlineWidth = None
+    leadTime = None
+    trailTime = None
+    width = None
+
+    _position = None
+    position = class_property(Position, 'position')
+
+    @property
+    def properties(self):
+        return super(Path, self).properties + ('show', 'color', 'resolution',
+                                               'outlineWidth', 'leadTime',
+                                               'trailTime', 'position', 'width')
+
+    def __init__(self, **kwargs):
+        if hasattr(kwargs, 'iteritems'):
+            iterator = kwargs.iteritems
+        elif hasattr(kwargs, 'items'):
+            iterator = kwargs.items
+        for k, v in iterator():
+            if k in self._properties:
+                setattr(self, k, v)
+            else:
+                raise ValueError('Key word %s not known' % k)
 
 
 class Polygon(_CZMLBaseObject):

--- a/czml/test_main.py
+++ b/czml/test_main.py
@@ -403,8 +403,8 @@ class CzmlClassesTestCase(unittest.TestCase):
         po2 = czml.PolylineOutline(**po_dict)
         self.assertEqual(po.data(), po2.data())
 
-    def testVertexPositions(self):
-        v = czml.VertexPositions()
+    def testPositions(self):
+        v = czml.Positions()
         l = geometry.LineString([(0, 0), (1, 1)])
         r = geometry.LinearRing([(0, 0), (1, 1), (1, 0), (0, 0)])
         ext = [(0, 0), (0, 2), (2, 2), (2, 0), (0, 0)]
@@ -420,7 +420,7 @@ class CzmlClassesTestCase(unittest.TestCase):
             [0.0, 0.0, 0, 0.0, 2.0, 0, 2.0, 2.0, 0, 2.0, 0.0, 0, 0.0, 0.0, 0],
             'cartographicDegrees':
             [0.0, 0.0, 0, 1.0, 1.0, 0, 1.0, 0.0, 0, 0.0, 0.0, 0]})
-        v2 = czml.VertexPositions()
+        v2 = czml.Positions()
         v2.loads(v.dumps())
         self.assertEqual(v.data(), v2.data())
         v.cartesian = None
@@ -449,19 +449,27 @@ class CzmlClassesTestCase(unittest.TestCase):
                                      })
         pg = czml.PolylineGlow(color={'rgba': [0, 255, 127, 55]}, glowPower=0.25)
         m2 = czml.Material(polylineGlow=pg)
-        p2 = czml.Polyline(show=False, width=7, followSurface=True, material=m2)
+        c2 = geometry.LineString([(1.6, 5.3, 10), (2.4, 4.2, 20), (3.8, 3.1, 30)])
+        o2 = czml.Positions(cartographicRadians=c2)
+        p2 = czml.Polyline(show=False, width=7, followSurface=True, material=m2, positions=o2)
         self.assertEqual(p2.data(), {'show': False, 'width': 7, 'followSurface': True,
                                      'material':
                                          {'polylineGlow':
                                               {'color': {'rgba': [0, 255, 127, 55]},
                                                'glowPower': 0.25},
                                           },
+                                     'positions':
+                                         {'cartographicRadians': [1.6, 5.3, 10,
+                                                                  2.4, 4.2, 20,
+                                                                  3.8, 3.1, 30]},
                                      })
         po = czml.PolylineOutline(color={'rgba': [0, 255, 127, 55]},
                                   outlineColor={'rgba': [0, 55, 127, 255]},
                                   outlineWidth=4)
         m3 = czml.Material(polylineOutline=po)
-        p3 = czml.Polyline(show=True, width=2, followSurface=False, material=m3)
+        c3 = geometry.LineString([(1000, 7500, 90), (2000, 6500, 50), (3000, 5500, 20)])
+        o3 = czml.Positions(cartesian=c3)
+        p3 = czml.Polyline(show=True, width=2, followSurface=False, material=m3, positions=o3)
         self.assertEqual(p3.data(), {'show': True, 'width': 2, 'followSurface': False,
                                      'material':
                                          {'polylineOutline':
@@ -469,6 +477,10 @@ class CzmlClassesTestCase(unittest.TestCase):
                                                'outlineColor': {'rgba': [0, 55, 127, 255]},
                                                'outlineWidth': 4},
                                           },
+                                     'positions':
+                                         {'cartesian': [1000, 7500, 90,
+                                                        2000, 6500, 50,
+                                                        3000, 5500, 20]},
                                      })
 
     def testPolygon(self):
@@ -613,7 +625,7 @@ class CzmlClassesTestCase(unittest.TestCase):
         pl.width = 10
         pl.outlineWidth = 2
         pl.show = True
-        v = czml.VertexPositions()
+        v = czml.Positions()
         v.cartographicDegrees = [0.0, 0.0, .0, 1.0, 1.0, 1.0]
         p4.vertexPositions = v
         p4.polyline = pl

--- a/czml/test_main.py
+++ b/czml/test_main.py
@@ -430,29 +430,46 @@ class CzmlClassesTestCase(unittest.TestCase):
             [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]})
 
     def testPolyline(self):
-        p = czml.Polyline()
-        p.color = {'rgba': [0, 255, 127, 55]}
-        self.assertEqual(p.data(), {'color':
-                {'rgba': [0, 255, 127, 55]},
-                'show': False})
-        p.outlineColor = {'rgbaf': [0.0, 0.255, 0.127, 0.55]}
-        self.assertEqual(p.data(), {'color':
-                    {'rgba': [0, 255, 127, 55]},
-                    'outlineColor': {'rgbaf': [0.0, 0.255, 0.127, 0.55]},
-                    'show': False})
-        p.width = 10
-        p.outlineWidth = 2
-        p.show = True
-        self.assertEqual(p.data(), {'color':
-                        {'rgba': [0, 255, 127, 55]},
-                    'width': 10,
-                    'outlineColor':
-                        {'rgbaf': [0.0, 0.255, 0.127, 0.55]},
-                    'outlineWidth': 2,
-                    'show': True})
-        p2 = czml.Polyline()
-        p2.loads(p.dumps())
-        self.assertEqual(p.data(), p2.data())
+        self.maxDiff = None
+        sc = czml.SolidColor(color={'rgba': [0, 255, 127, 55]})
+        m1 = czml.Material(solidColor=sc)
+        c1 = geometry.LineString([(-162, 41, 0), (-151, 43, 0), (-140, 45, 0)])
+        o1 = czml.Positions(cartographicDegrees=c1)
+        p1 = czml.Polyline(show=True, width=5, followSurface=False, material=m1, positions=o1)
+        self.assertEqual(p1.data(), {'show': True, 'width': 5, 'followSurface': False,
+                                     'material':
+                                         {'solidColor':
+                                              {'color': {'rgba': [0, 255, 127, 55]}},
+                                          },
+                                     'positions':
+                                         {'cartographicDegrees': [-162, 41, 0,
+                                                                  -151, 43, 0,
+                                                                  -140, 45, 0]},
+                                                                  
+                                     })
+        pg = czml.PolylineGlow(color={'rgba': [0, 255, 127, 55]}, glowPower=0.25)
+        m2 = czml.Material(polylineGlow=pg)
+        p2 = czml.Polyline(show=False, width=7, followSurface=True, material=m2)
+        self.assertEqual(p2.data(), {'show': False, 'width': 7, 'followSurface': True,
+                                     'material':
+                                         {'polylineGlow':
+                                              {'color': {'rgba': [0, 255, 127, 55]},
+                                               'glowPower': 0.25},
+                                          },
+                                     })
+        po = czml.PolylineOutline(color={'rgba': [0, 255, 127, 55]},
+                                  outlineColor={'rgba': [0, 55, 127, 255]},
+                                  outlineWidth=4)
+        m3 = czml.Material(polylineOutline=po)
+        p3 = czml.Polyline(show=True, width=2, followSurface=False, material=m3)
+        self.assertEqual(p3.data(), {'show': True, 'width': 2, 'followSurface': False,
+                                     'material':
+                                         {'polylineOutline':
+                                              {'color': {'rgba': [0, 255, 127, 55]},
+                                               'outlineColor': {'rgba': [0, 55, 127, 255]},
+                                               'outlineWidth': 4},
+                                          },
+                                     })
 
     def testPolygon(self):
         p = czml.Polygon()
@@ -584,6 +601,8 @@ class CzmlClassesTestCase(unittest.TestCase):
                                     'point': {'color':
                                         {'rgba': [0, 255, 127, 55]},
                                         'show': True}})
+
+        """
         p32 = czml.CZMLPacket(id='abc')
         p32.loads(p3.dumps())
         self.assertEqual(p3.data(), p32.data())
@@ -629,6 +648,7 @@ class CzmlClassesTestCase(unittest.TestCase):
         p52 = czml.CZMLPacket(id='abc')
         p52.loads(p5.dumps())
         self.assertEqual(p5.data(), p52.data())
+        """
         return p
 
     def testCZML(self):

--- a/czml/test_main.py
+++ b/czml/test_main.py
@@ -37,6 +37,7 @@ from pygeoif import geometry
 class BaseClassesTestCase(unittest.TestCase):
 
     def test_DateTimeAware(self):
+
         dtob = czml._DateTimeAware()
         now = datetime.now()
         est_now = eastern.localize(now)
@@ -107,6 +108,7 @@ class BaseClassesTestCase(unittest.TestCase):
         self.assertEqual(dtob.data(), json.loads(est_jst))
 
     def test_Coordinates(self):
+
         coord = czml._Coordinates([0, 1])
         self.assertEqual(len(coord.coords), 1)
         self.assertEqual(coord.coords[0].x, 0)
@@ -166,9 +168,11 @@ class BaseClassesTestCase(unittest.TestCase):
 
 
     def testScale(self):
+
         pass
 
     def testColor(self):
+
         col = czml.Color()
         col.rgba = [0, 255, 127]
         self.assertEqual(col.rgba, [0, 255, 127, 1])
@@ -192,6 +196,7 @@ class BaseClassesTestCase(unittest.TestCase):
         self.assertEqual(col.data(), col2.data())
 
     def test_hexcolor_to_rgba(self):
+
         col = '0000'
         ashex = utils.hexcolor_to_rgba
         self.assertEqual(ashex(col), (0, 0, 0, 0))
@@ -222,6 +227,7 @@ class BaseClassesTestCase(unittest.TestCase):
 class CzmlClassesTestCase(unittest.TestCase):
 
     def testPosition(self):
+
         pos = czml.Position()
         now = datetime.now()
         pos.epoch = now
@@ -229,12 +235,14 @@ class CzmlClassesTestCase(unittest.TestCase):
         pos.cartographicRadians = coords
         self.assertEqual(pos.data()['cartographicRadians'],
             coords)
+
         js = {'epoch': now.isoformat(), 'cartographicRadians': coords}
         self.assertEqual(pos.data(), js)
         self.assertEqual(pos.dumps(), json.dumps(js))
         pos.cartographicDegrees = coords
         self.assertEqual(pos.data()['cartographicDegrees'],
             coords)
+
         pos.cartesian = coords
         self.assertEqual(pos.data()['cartesian'],
             coords)
@@ -243,6 +251,7 @@ class CzmlClassesTestCase(unittest.TestCase):
         self.assertEqual(pos.data(), pos2.data())
 
     def testRadii(self):
+
         pos = czml.Radii()
         now = datetime.now()
         pos.epoch = now
@@ -250,27 +259,33 @@ class CzmlClassesTestCase(unittest.TestCase):
         pos.cartesian = coords
         self.assertEqual(pos.data()['cartesian'],
             coords)
+
         js = {'epoch': now.isoformat(), 'cartesian': coords}
         self.assertEqual(pos.data(), js)
         self.assertEqual(pos.dumps(), json.dumps(js))
+
         pos.cartographicDegrees = coords
         self.assertEqual(pos.data()['cartesian'],
             coords)
+
         pos2 = czml.Radii()
         pos2.loads(pos.dumps())
         self.assertEqual(pos.data(), pos2.data())
 
     def testPoint(self):
+
         point = czml.Point()
         point.color = {'rgba': [0, 255, 127, 55]}
         self.assertEqual(point.data(), {'color':
                 {'rgba': [0, 255, 127, 55]},
                 'show': False})
+
         point.outlineColor = {'rgbaf': [0.0, 0.255, 0.127, 0.55]}
         self.assertEqual(point.data(), {'color':
                     {'rgba': [0, 255, 127, 55]},
                     'outlineColor': {'rgbaf': [0.0, 0.255, 0.127, 0.55]},
                     'show': False})
+
         point.pixelSize = 10
         point.outlineWidth = 2
         point.show = True
@@ -281,22 +296,27 @@ class CzmlClassesTestCase(unittest.TestCase):
                         {'rgbaf': [0.0, 0.255, 0.127, 0.55]},
                     'outlineWidth': 2,
                     'show': True})
+
         p2 = czml.Point()
         p2.loads(point.dumps())
         self.assertEqual(point.data(), p2.data())
 
     def testLabel(self):
+
         l = czml.Label()
         l.text = 'test label'
         l.show = False
         self.assertEqual(l.data(), {'text': 'test label', 'show': False})
+
         l.show = True
         self.assertEqual(l.data(), {'text': 'test label', 'show': True})
+
         l2 = czml.Label()
         l2.loads(l.dumps())
         self.assertEqual(l.data(), l2.data())
 
     def testBillboard(self):
+
         bb = czml.Billboard()
         bb.image = 'http://localhost/img.png'
         bb.scale = 0.7
@@ -306,11 +326,13 @@ class CzmlClassesTestCase(unittest.TestCase):
             {'image': 'http://localhost/img.png', 'scale': 0.7,
             'color': {'rgba': [0, 255, 127, 55]},
             'show': True})
+
         bb2 = czml.Billboard()
         bb2.loads(bb.dumps())
         self.assertEqual(bb.data(), bb2.data())
 
     def testClock(self):
+
         c = czml.Clock()
         c.currentTime = '2017-08-21T16:50:00Z'
         c.multiplier = 3
@@ -321,20 +343,24 @@ class CzmlClassesTestCase(unittest.TestCase):
              'multiplier': 3,
              'range': 'UNBOUNDED',
              'step': 'SYSTEM_CLOCK_MULTIPLIER'})
+
         c2 = czml.Clock()
         c2.loads(c.dumps())
         self.assertEqual(c.data(), c2.data())
 
     def testMaterial(self):
+
         red = czml.Color(rgba=(255, 0, 0, 64))
         mat = czml.Material()
         mat.solidColor = {'color': red}
         mat_dict = {'solidColor': {'color': {'rgba': [255, 0, 0, 64]}}}
         self.assertEqual(mat.data(), mat_dict)
+
         mat2 = czml.Material(**mat_dict)
         self.assertEqual(mat.data(), mat2.data())
 
     def testGrid(self):
+
         red = czml.Color(rgba=(255, 0, 0, 64))
         g = czml.Grid()
         g.color = red
@@ -345,19 +371,22 @@ class CzmlClassesTestCase(unittest.TestCase):
         g_dict = {'color': {'rgba': [255, 0, 0, 64]}, 'cellAlpha': 0.5, 'lineCount': 4,
                   'lineThickness': 1.5, 'lineOffset': 0.75}
         self.assertEqual(g.data(), g_dict)
+
         g2 = czml.Grid(**g_dict)
         self.assertEqual(g.data(), g2.data())
 
     def testImage(self):
-        i = czml.Image()
-        i.image = 'http://localhost/img.png'
+
+        i = czml.Image(image='http://localhost/img.png')
         i.repeat = 3
         i_dict = {'image': 'http://localhost/img.png', 'repeat': 3}
         self.assertEqual(i.data(), i_dict)
+
         i2 = czml.Image(**i_dict)
         self.assertEqual(i.data(), i2.data())
 
     def testStripe(self):
+
         red = czml.Color(rgba=(255, 0, 0, 64))
         grn = czml.Color(rgba=(0, 255, 0, 64))
         s = czml.Stripe()
@@ -369,29 +398,35 @@ class CzmlClassesTestCase(unittest.TestCase):
         s_dict = {'orientation': 'HORIZONTAL', 'evenColor': {'rgba': [255, 0, 0, 64]},
                   'oddColor': {'rgba': [0, 255, 0, 64]}, 'offset': 1.5, 'repeat': 3.6}
         self.assertEqual(s.data(), s_dict)
+
         s2 = czml.Stripe(**s_dict)
         self.assertEqual(s.data(), s2.data())
 
     def testSolidColor(self):
+
         red = czml.Color(rgba=(255, 0, 0, 64))
         sc = czml.SolidColor()
         sc.color = red
         sc_dict = {'color': {'rgba': [255, 0, 0, 64]}}
         self.assertEqual(sc.data(), sc_dict)
+
         sc2 = czml.SolidColor(**sc_dict)
         self.assertEqual(sc.data(), sc2.data())
 
     def testPolylineGlow(self):
+
         red = czml.Color(rgba=(255, 0, 0, 64))
         pg = czml.PolylineGlow()
         pg.color = red
         pg.glowPower = 0.25
         pg_dict = {'color': {'rgba': [255, 0, 0, 64]}, 'glowPower': 0.25}
         self.assertEqual(pg.data(), pg_dict)
+
         pg2 = czml.PolylineGlow(**pg_dict)
         self.assertEqual(pg.data(), pg2.data())
 
     def testPolylineOutline(self):
+
         red = czml.Color(rgba=(255, 0, 0, 64))
         grn = czml.Color(rgba=(0, 255, 0, 64))
         po = czml.PolylineOutline()
@@ -400,10 +435,12 @@ class CzmlClassesTestCase(unittest.TestCase):
         po.outlineWidth = 4
         po_dict = {'color': {'rgba': [255, 0, 0, 64]}, 'outlineColor': {'rgba': [0, 255, 0, 64]}, 'outlineWidth': 4}
         self.assertEqual(po.data(), po_dict)
+
         po2 = czml.PolylineOutline(**po_dict)
         self.assertEqual(po.data(), po2.data())
 
     def testPositions(self):
+
         v = czml.Positions()
         l = geometry.LineString([(0, 0), (1, 1)])
         r = geometry.LinearRing([(0, 0), (1, 1), (1, 0), (0, 0)])
@@ -420,22 +457,77 @@ class CzmlClassesTestCase(unittest.TestCase):
             [0.0, 0.0, 0, 0.0, 2.0, 0, 2.0, 2.0, 0, 2.0, 0.0, 0, 0.0, 0.0, 0],
             'cartographicDegrees':
             [0.0, 0.0, 0, 1.0, 1.0, 0, 1.0, 0.0, 0, 0.0, 0.0, 0]})
+
         v2 = czml.Positions()
         v2.loads(v.dumps())
         self.assertEqual(v.data(), v2.data())
+
         v.cartesian = None
         v.cartographicDegrees = None
         v.cartographicRadians = [0.0, 0.0, .0, 1.0, 1.0, 1.0]
         self.assertEqual(v.data(), {'cartographicRadians':
             [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]})
 
+    def testPath(self):
+
+        sc = czml.SolidColor(color={'rgba': [0, 255, 127, 55]})
+        m1 = czml.Material(solidColor=sc)
+        c1 = [0, -62, 141, 0,
+              2, -51, 143, 0,
+              4, -40, 145, 0]
+        v1 = czml.Position(cartographicDegrees=c1)
+        p1 = czml.Path(show=True, width=5, leadTime=2, trailTime=6,
+                       resolution=3, material=m1, position=v1)
+        self.assertEqual(p1.data(), {'show': True, 'width': 5, 'leadTime': 2,
+                                     'trailTime': 6, 'resolution': 3,
+                                     'material':
+                                         {'solidColor':
+                                              {'color': {'rgba': [0, 255, 127, 55]}},
+                                          },
+                                     'position':
+                                         {'cartographicDegrees': [0, -62, 141, 0,
+                                                                  2, -51, 143, 0,
+                                                                  4, -40, 145, 0]},
+                                                                  
+                                     })
+
+        p2 = czml.Path()
+        p2.loads(p1.dumps())
+        self.assertEqual(p2.data(), p1.data())
+
+        po = czml.PolylineOutline(color={'rgba': [0, 255, 127, 55]},
+                                  outlineColor={'rgba': [0, 55, 127, 255]},
+                                  outlineWidth=4)
+        m2 = czml.Material(polylineOutline=po)
+        c2 = [0, 1000, 7500, 90,
+              4, 2000, 6500, 50,
+              8, 3000, 5500, 20]
+        v2 = czml.Position(cartesian=c2)
+        p2.show = False
+        p2.material = m2
+        p2.position = v2
+        self.assertEqual(p2.data(), {'show': False, 'width': 5, 'leadTime': 2,
+                                     'trailTime': 6, 'resolution': 3,
+                                     'material':
+                                         {'polylineOutline':
+                                              {'color': {'rgba': [0, 255, 127, 55]},
+                                               'outlineColor': {'rgba': [0, 55, 127, 255]},
+                                               'outlineWidth': 4},
+                                          },
+                                     'position':
+                                         {'cartesian': [0, 1000, 7500, 90,
+                                                        4, 2000, 6500, 50,
+                                                        8, 3000, 5500, 20]},
+                                     })
+        
+
     def testPolyline(self):
-        self.maxDiff = None
+
         sc = czml.SolidColor(color={'rgba': [0, 255, 127, 55]})
         m1 = czml.Material(solidColor=sc)
         c1 = geometry.LineString([(-162, 41, 0), (-151, 43, 0), (-140, 45, 0)])
-        o1 = czml.Positions(cartographicDegrees=c1)
-        p1 = czml.Polyline(show=True, width=5, followSurface=False, material=m1, positions=o1)
+        v1 = czml.Positions(cartographicDegrees=c1)
+        p1 = czml.Polyline(show=True, width=5, followSurface=False, material=m1, positions=v1)
         self.assertEqual(p1.data(), {'show': True, 'width': 5, 'followSurface': False,
                                      'material':
                                          {'solidColor':
@@ -447,11 +539,12 @@ class CzmlClassesTestCase(unittest.TestCase):
                                                                   -140, 45, 0]},
                                                                   
                                      })
+
         pg = czml.PolylineGlow(color={'rgba': [0, 255, 127, 55]}, glowPower=0.25)
         m2 = czml.Material(polylineGlow=pg)
         c2 = geometry.LineString([(1.6, 5.3, 10), (2.4, 4.2, 20), (3.8, 3.1, 30)])
-        o2 = czml.Positions(cartographicRadians=c2)
-        p2 = czml.Polyline(show=False, width=7, followSurface=True, material=m2, positions=o2)
+        v2 = czml.Positions(cartographicRadians=c2)
+        p2 = czml.Polyline(show=False, width=7, followSurface=True, material=m2, positions=v2)
         self.assertEqual(p2.data(), {'show': False, 'width': 7, 'followSurface': True,
                                      'material':
                                          {'polylineGlow':
@@ -463,14 +556,20 @@ class CzmlClassesTestCase(unittest.TestCase):
                                                                   2.4, 4.2, 20,
                                                                   3.8, 3.1, 30]},
                                      })
+
+        p3 = czml.Polyline()
+        p3.loads(p2.dumps())
+        self.assertEqual(p3.data(), p2.data())
+
         po = czml.PolylineOutline(color={'rgba': [0, 255, 127, 55]},
                                   outlineColor={'rgba': [0, 55, 127, 255]},
                                   outlineWidth=4)
         m3 = czml.Material(polylineOutline=po)
         c3 = geometry.LineString([(1000, 7500, 90), (2000, 6500, 50), (3000, 5500, 20)])
-        o3 = czml.Positions(cartesian=c3)
-        p3 = czml.Polyline(show=True, width=2, followSurface=False, material=m3, positions=o3)
-        self.assertEqual(p3.data(), {'show': True, 'width': 2, 'followSurface': False,
+        v3 = czml.Positions(cartesian=c3)
+        p3.material = m3
+        p3.positions = v3
+        self.assertEqual(p3.data(), {'show': False, 'width': 7, 'followSurface': True,
                                      'material':
                                          {'polylineOutline':
                                               {'color': {'rgba': [0, 255, 127, 55]},
@@ -483,23 +582,130 @@ class CzmlClassesTestCase(unittest.TestCase):
                                                         3000, 5500, 20]},
                                      })
 
+
+
     def testPolygon(self):
-        p = czml.Polygon()
-        m = czml.Material()
-        sc = czml.SolidColor(color={'rgba': [0, 255, 127, 55]})
-        m.solidColor = sc
-        p.material = m
-        self.assertEqual(p.data(),
-            {'material':
-                {'solidColor':
-                    {'color': {'rgba': [0, 255, 127, 55]}}
-            }   }
-            )
-        p2 = czml.Polygon()
-        p2.loads(p.dumps())
-        self.assertEqual(p.data(), p2.data())
-        p3 = czml.Polygon(color={'rgba': [0, 255, 127, 55]})
-        self.assertEqual(p.data(), p3.data())
+
+        img = czml.Image(image='http://localhost/img.png', repeat=2)
+        mat = czml.Material(image=img)
+        pts = geometry.LineString([(50, 20, 2), (60, 30, 3), (50, 30, 4), (60, 20, 5)])
+        pos = czml.Positions(cartographicDegrees=pts)
+        col = {'rgba': [0, 255, 127, 55]}
+        pol = czml.Polygon(show=True, material=mat, positions=pos, perPositionHeight=True,
+                           fill=True, outline=True, outlineColor=col)
+        self.assertEqual(pol.data(), {'show': True, 'fill': True, 'outline': True,
+                                      'perPositionHeight': True,
+                                      'outlineColor': {'rgba': [0, 255, 127, 55]},
+                                      'material':
+                                          {'image':
+                                              {'image': 'http://localhost/img.png',
+                                               'repeat': 2},
+                                          },
+                                      'positions':
+                                          {'cartographicDegrees': [50, 20, 2,
+                                                                   60, 30, 3,
+                                                                   50, 30, 4,
+                                                                   60, 20, 5]},
+                                      })
+
+        pol2 = czml.Polygon()
+        pol2.loads(pol.dumps())
+        self.assertEqual(pol2.data(), pol.data())
+
+        grid = czml.Grid(color={'rgba': [0, 55, 127, 255]}, cellAlpha=0.4,
+                         lineCount=5, lineThickness=2, lineOffset=0.3)
+        mat2 = czml.Material(grid=grid)
+        pts2 = geometry.LineString([(1.5, 1.2, 0), (1.6, 1.3, 0), (1.5, 1.3, 0), (1.6, 1.2, 0)])
+        pos2 = czml.Positions(cartographicRadians=pts2)
+        pol2.material = mat2
+        pol2.positions = pos2
+        pol2.perPositionHeight = False
+        pol2.height = 7
+        pol2.extrudedHeight = 30
+        self.assertEqual(pol2.data(), {'show': True, 'fill': True, 'outline': True,
+                                       'perPositionHeight': False,
+                                       'height': 7, 'extrudedHeight': 30,
+                                       'outlineColor': {'rgba': [0, 255, 127, 55]},
+                                       'material':
+                                           {'grid':
+                                                {'color': {'rgba': [0, 55, 127, 255]},
+                                                 'cellAlpha': 0.4,
+                                                 'lineCount': 5,
+                                                 'lineThickness': 2,
+                                                 'lineOffset': 0.3},
+                                            },
+                                       'positions':
+                                           {'cartographicRadians': [1.5, 1.2, 0,
+                                                                    1.6, 1.3, 0,
+                                                                    1.5, 1.3, 0,
+                                                                    1.6, 1.2, 0]},
+                                       })
+
+
+    def testEllipse(self):
+
+        sc = czml.SolidColor(color={'rgba': [127, 127, 127, 255]})
+        mat1 = czml.Material(solidColor=sc)
+        pts1 = [50, 20, 2]
+        pos1 = czml.Position(cartographicDegrees=pts1)
+        ell1 = czml.Ellipse(show=True, fill=True, height=50, extrudedHeight=200,
+                            outline=True, outlineColor={'rgba': [0, 255, 127, 55]},
+                            semiMajorAxis=150, semiMinorAxis=75, numberOfVerticalLines=800,
+                            rotation=1.2, material=mat1, position=pos1)
+
+        self.assertEqual(ell1.data(), {'show': True, 'fill': True, 'outline': True,
+                                       'height': 50, 'extrudedHeight': 200, 'rotation': 1.2,
+                                       'semiMajorAxis': 150, 'semiMinorAxis': 75,
+                                       'numberOfVerticalLines': 800,
+                                       'outlineColor': {'rgba': [0, 255, 127, 55]},
+                                       'material':
+                                           {'solidColor':
+                                                {'color': {'rgba': [127, 127, 127, 255]}},
+                                            },
+                                       'position':
+                                           {'cartographicDegrees': [50, 20, 2]},
+                                       })
+
+        ell2 = czml.Ellipse()
+        ell2.loads(ell1.dumps())
+        self.assertEqual(ell2.data(), ell1.data())
+
+        strp = czml.Stripe(evenColor={'rgba': [127, 55, 255, 255]},
+                           oddColor={'rgba': [127, 255, 55, 127]},
+                           offset=1.3, repeat=64, orientation='VERTICAL')
+        mat2 = czml.Material(stripe=strp)
+        pts2 = [0, 1.5, 1.2, 0,
+                2, 1.6, 1.3, 0,
+                4, 1.5, 1.3, 0,
+                6, 1.6, 1.2, 0]
+        pos2 = czml.Position(cartographicRadians=pts2)
+        ell2.material = mat2
+        ell2.position = pos2
+        ell2.perPositionHeight = False
+        ell2.height = 7
+        ell2.extrudedHeight = 30
+        ell2.semiMajorAxis = 600
+        ell2.semiMinorAxis = 400
+        self.assertEqual(ell2.data(), {'show': True, 'fill': True, 'outline': True,
+                                       'height': 7, 'extrudedHeight': 30, 'rotation': 1.2,
+                                       'semiMajorAxis': 600, 'semiMinorAxis': 400,
+                                       'numberOfVerticalLines': 800,
+                                       'outlineColor': {'rgba': [0, 255, 127, 55]},
+                                       'material':
+                                           {'stripe':
+                                                {'evenColor': {'rgba': [127, 55, 255, 255]},
+                                                 'oddColor': {'rgba': [127, 255, 55, 127]},
+                                                 'offset': 1.3,
+                                                 'repeat': 64,
+                                                 'orientation': 'VERTICAL'},
+                                            },
+                                       'position':
+                                           {'cartographicRadians': [0, 1.5, 1.2, 0,
+                                                                    2, 1.6, 1.3, 0,
+                                                                    4, 1.5, 1.3, 0,
+                                                                    6, 1.6, 1.2, 0]},
+                                       })
+
 
     def testEllipsoid(self):
         ellipsoid_value = {'radii': {'cartesian': [1000.0, 2000.0, 3000.0]},
@@ -613,54 +819,6 @@ class CzmlClassesTestCase(unittest.TestCase):
                                     'point': {'color':
                                         {'rgba': [0, 255, 127, 55]},
                                         'show': True}})
-
-        """
-        p32 = czml.CZMLPacket(id='abc')
-        p32.loads(p3.dumps())
-        self.assertEqual(p3.data(), p32.data())
-        p4 = czml.CZMLPacket(id='defg')
-
-        pl = czml.Polyline()
-        pl.color = {'rgba': [0, 255, 127, 55]}
-        pl.width = 10
-        pl.outlineWidth = 2
-        pl.show = True
-        v = czml.Positions()
-        v.cartographicDegrees = [0.0, 0.0, .0, 1.0, 1.0, 1.0]
-        p4.vertexPositions = v
-        p4.polyline = pl
-        self.assertEqual(p4.data(),
-             {'polyline':
-                {'color': {'rgba': [0, 255, 127, 55]},
-                'width': 10,
-                'outlineWidth': 2,
-                'show': True},
-            'id': 'defg',
-            'vertexPositions':
-                {'cartographicDegrees':
-                    [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]}
-            })
-        p42 = czml.CZMLPacket(id='abc')
-        p42.loads(p4.dumps())
-        self.assertEqual(p4.data(), p42.data())
-        p5 = czml.CZMLPacket(id='efgh')
-        p5.vertexPositions = v
-        poly = czml.Polygon(color={'rgba': [0, 255, 127, 55]})
-        p5.polygon = poly
-        self.assertEqual(p5.data(),
-            {'polygon':
-                {'material':
-                    {'solidColor':
-                        {'color':
-                            {'rgba': [0, 255, 127, 55]}}}},
-                    'id': 'efgh',
-                    'vertexPositions':
-                        {'cartographicDegrees':
-                            [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]}})
-        p52 = czml.CZMLPacket(id='abc')
-        p52.loads(p5.dumps())
-        self.assertEqual(p5.data(), p52.data())
-        """
         return p
 
     def testCZML(self):


### PR DESCRIPTION
# Overview

This branch began as I went to use the new material classes added in [Material Subclasses](https://github.com/cleder/czml/pull/8) only to find that the `Polyline` class was never properly set up to handle materials.

Digging a bit deeper I found some redundancy and inconsistency throughout the two-dimensional object classes, along with several object properties that were missing or did not match the [CZML documentation](https://github.com/AnalyticalGraphicsInc/cesium/wiki/CZML-Content) so this branch seeks to clean most of that up.

## Approach

This branch was heavily test-driven in its development. In `test_main.py` there are now completely rebuilt test functions for `Path`, `Polygon`, `Polyline`, and `Ellipse`. Each function seeks to work the vast majority of properties for each object, both through extensive definitions as well as cloning objects and altering properties.

In the process many of the objects and assertions in `testCZMLPacket` got nuked. Given comments from @cleder on #8 it seems like this is pretty reasonable approach. The upshot is that the test cases for the four 2d objects work some of the commonly used subclasses pretty completely, including `Material` (and its subclasses), `Position`, `Positions`, `Color`, and `Number`.

## Class definition consistency

Please note how I changed the class definitions for the four two-dimensional object types in `czml.py` (`Path`, `Polygon`, `Polyline`, and `Ellipse`). Beforehand there was a lot of code duplication and inconsistent property definitions. With the robust getter/setter methods coming from `class_property` and the argument loading happening nicely through `_CZMLBaseObject` I was able to strip these specific object class definitions down to little more than a listing of properties specific to that object. Now these definitions are all pretty consistent and map to the documentation.

## s/VertexPositions/Positions/g

I noticed that most of the position definitions throughout were VertexPosition or VertexPositions, even in the in-line documentation. I'm guessing this was just from an earlier version of CZML that used those names, but now it's all Position and Positions so that was a straightforward replace.

## Clock

The `Clock` class, introduced in the unmerged #6, was something I merged into my own fork because it was working and I was ready to use it. I didn't feel like cherry-picking it back out, and it's pretty small, so `Clock` is bundled in with this. I'll close #6.